### PR TITLE
taryfa bez rabatow po okresie umowy

### DIFF
--- a/lib/LMS.class.php
+++ b/lib/LMS.class.php
@@ -113,7 +113,7 @@ class LMS {
 	    .' AND a.dateto!=0'
 	    .' AND a.dateto<='.$dateto
 	    .' AND a.dateto>'.time()
-	    .' AND NOT EXISTS (SELECT 1 FROM assignments aa WHERE aa.customerid=a.customerid AND aa.datefrom>a.dateto LIMIT 1)'
+	    .' AND NOT EXISTS (SELECT 1 FROM assignments aa WHERE aa.customerid=a.customerid AND aa.datefrom>a.dateto AND aa.discount>0 LIMIT 1)'
 	    ;
 	}
 	elseif ($dni=='-2')


### PR DESCRIPTION
moim klientom przy umowach na czas okreslony dodaje zawsze taryfe ktora obowiazywac bedzie po okresie okreslonym w umowie. Wtedy ta taryfa jest taka jak poprzednia, ale bez rabatu.
dodanie 'AND aa.discount>0' spowodowalo, ze na liscie pojawili sie moi klienci bedacy w takiej sytuacji jak opisalem powyzej.
