### PR TITLE
Przykładowa konfiguracja dla FreeRADIUS v3.x

### DIFF
--- a/sample/radius-sql-v3.conf
+++ b/sample/radius-sql-v3.conf
@@ -1,0 +1,116 @@
+
+# FreeRADIUS v3.x
+#
+# Zmienna username_column pobiera za pomocą xlat nazwę kolumny,
+# która służy do autentykacji usera dla sesji pppoe ( id,name, pppoelogin )
+# Dzięki tej zmiennej w aplikacji w menu RADIUS->Konfiguracja wartość parametru auth_login
+# jest pobierana dynamicznie, a nazwa kolumny zostaje automatycznie zmieniona w zapytaniu poniżej.
+# 
+# Adam Bugajewski
+# 
+
+username_column =  "%{pppoe:SELECT value FROM uiconfig WHERE section = \"radius\" AND var = \"auth_login\"}"
+
+authorize_check_query = "SELECT \
+	    id, lower(${username_column}) as UserName , 'Cleartext-Password' as Attribute , passwd as Value, ':=' as op \
+	FROM nodes \
+	WHERE ${username_column} = '%{User-Name}'\
+	UNION \
+        SELECT id, lower(${username_column}) as UserName , 'Simultaneous-Use' as Attribute, '1' as Value, ':=' as op \
+        FROM nodes \
+        WHERE ${username_column} = '%{User-Name}'\
+	UNION \
+	SELECT 0 AS id, '%{User-Name}' AS UserName, 'Mikrotik-Total-Limit' AS Attribute, \
+            CONCAT(ROUND(COALESCE(x.dlimit, y.dlimit))) AS Value, ':=' AS op \
+	FROM (\
+	    SELECT n.id, MIN(n.${username_column}) AS name, SUM(t.dlimit/o.cnt) AS dlimit \
+	    FROM nodeassignments na \
+	    JOIN assignments a ON (na.assignmentid = a.id) \
+	    JOIN tariffs t ON (a.tariffid = t.id)\
+    	    JOIN nodes n ON (na.nodeid = n.id)\
+    	    JOIN (\
+    		SELECT assignmentid, COUNT(*) AS cnt\
+    		FROM nodeassignments \
+    		GROUP BY assignmentid \
+    	    ) o ON (o.assignmentid = na.assignmentid)\
+    	    WHERE (a.datefrom <= unix_timestamp() OR a.datefrom = 0) \
+    		AND (a.dateto > unix_timestamp() OR a.dateto = 0) \
+    		AND a.suspended = 0 AND n.${username_column} = '%{User-Name}'\
+	    GROUP BY n.id\
+        ) x\
+        LEFT JOIN ( \
+    	    SELECT SUM(t.dlimit)/o.cnt AS dlimit\
+            FROM assignments a\
+            JOIN tariffs t ON (a.tariffid = t.id)\
+            JOIN nodes n ON (a.customerid = n.ownerid)\
+            JOIN ( \
+        	SELECT COUNT(*) AS cnt, ownerid \
+        	FROM nodes\
+        	WHERE NOT EXISTS (\
+        	    SELECT 1 FROM nodeassignments, assignments a \
+        	    WHERE assignmentid = a.id AND nodeid = nodes.id \
+        		AND a.suspended = 0 AND (a.dateto > unix_timestamp() OR a.dateto = 0))\
+                GROUP BY ownerid\
+            ) o ON (o.ownerid = n.ownerid)\
+            WHERE (a.datefrom <= unix_timestamp() OR a.datefrom = 0) \
+        	AND (a.dateto > unix_timestamp() OR a.dateto = 0) \
+        	AND a.suspended = 0 AND t.dlimit != '0'\
+                AND NOT EXISTS (\
+            	    SELECT 1 FROM nodeassignments \
+            	    WHERE assignmentid = a.id)\
+            	AND n.${username_column} = '%{User-Name}'\
+            GROUP BY n.id\
+        ) y ON (1=1);"
+
+    authorize_reply_query = "SELECT \
+	    id, lower(${username_column}) as UserName , 'Framed-IP-Address' as Attribute, inet_ntoa(ipaddr) as Value, ':=' as op \
+	FROM nodes \
+	WHERE ${username_column} = '%{User-Name}'\
+	UNION\
+        SELECT 0 AS id, '%{User-Name}' AS UserName, 'Mikrotik-Rate-Limit' AS Attribute,\
+             CONCAT(ROUND(COALESCE(x.upceil, y.upceil, z.upceil)),'k','/', ROUND(COALESCE(x.downceil, y.downceil, z.downceil)),'k') AS Value, ':=' AS op\
+        FROM (\
+    	    SELECT n.id, MIN(n.${username_column}) AS name, SUM(t.downceil/o.cnt) AS downceil, SUM(t.upceil/o.cnt) AS upceil\
+            FROM nodeassignments na\
+            JOIN assignments a ON (na.assignmentid = a.id)\
+ 	    JOIN tariffs t ON (a.tariffid = t.id)\
+	    JOIN nodes n ON (na.nodeid = n.id)\
+	    JOIN (\
+		SELECT assignmentid, COUNT(*) AS cnt\
+	        FROM nodeassignments \
+	        GROUP BY assignmentid\
+	    ) o ON (o.assignmentid = na.assignmentid)\
+	    WHERE (a.datefrom <= unix_timestamp() OR a.datefrom = 0) \
+		AND (a.dateto > unix_timestamp() OR a.dateto = 0) \
+		AND a.suspended = 0 AND n.${username_column} = '%{User-Name}'\
+	    GROUP BY n.id\
+	) x\
+	LEFT JOIN (\
+	    SELECT SUM(t.downceil)/o.cnt AS downceil,\
+		SUM(t.upceil)/o.cnt AS upceil\
+	    FROM assignments a\
+	    JOIN tariffs t ON (a.tariffid = t.id)\
+	    JOIN nodes n ON (a.customerid = n.ownerid)\
+	    JOIN (\
+		SELECT COUNT(*) AS cnt, ownerid FROM nodes \
+		WHERE NOT EXISTS (\
+		    SELECT 1 FROM nodeassignments, assignments a \
+		    WHERE assignmentid = a.id AND nodeid = nodes.id \
+			AND a.suspended = 0 AND (a.dateto > unix_timestamp() OR a.dateto = 0))\
+	        GROUP BY ownerid \
+	    ) o ON (o.ownerid = n.ownerid)\
+	    WHERE (a.datefrom <= unix_timestamp() OR a.datefrom = 0) \
+		AND (a.dateto > unix_timestamp() OR a.dateto = 0) AND a.suspended = 0\
+	        AND NOT EXISTS (SELECT 1 FROM nodeassignments WHERE assignmentid = a.id) \
+	    	AND n.${username_column} = '%{User-Name}'\
+	    GROUP BY n.id\
+	) y ON (1=1)\
+	RIGHT JOIN (\
+	    SELECT n.id, n.${username_column}, 64 AS downceil, 64 AS upceil\
+            FROM nodes n WHERE n.${username_column} = '%{User-Name}'\
+        ) z ON (1=1)\
+        UNION\
+        SELECT id, UserName, Attribute, Value, op \
+        FROM ${authreply_table} \
+        WHERE Username = '%{SQL-User-Name}' \
+        ORDER BY id;"


### PR DESCRIPTION
Przykładowa konfiguracja zapytań SQL dla FreeRADIUS v3.x.
Plik zawiera dodatkową zmienną służącą do dynamicznego wyboru kolumny autentykacji użytkownika pppoe.